### PR TITLE
Add support for specifying Discovery Prefix and entity ID prefix

### DIFF
--- a/ecowitt/CHANGELOG.md
+++ b/ecowitt/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2022.05.0-3
+* Add support for upstream options:
+  * `hass_discovery_prefix` - specifies the mqtt discovery prefix (upstream: `--hass-discovery-prefix`).
+  * `hass_entity_id_prefix` - specifies the entity ID prefix (upstream: `--hass-entity-id-prefix`).
+
 ## 2022.05.0-2
 * Add `init: false` to the configuration to fix bootup bug
 

--- a/ecowitt/DOCS.md
+++ b/ecowitt/DOCS.md
@@ -16,6 +16,10 @@ These are the configuration options you can use:
 
 `mqtt_pass` - Set the password for the MQTT user.
 
+`hass_discovery_prefix` - The Home Assistant discovery prefix to use.
+
+`hass_entity_id_prefix` - The prefix to use for Home Assistant entity IDs.
+
 
 Use the following settings in the custom weather provider page of the 'WS View' app.
 Protocol Type: Ecowitt

--- a/ecowitt/config.json
+++ b/ecowitt/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Ecowitt",
-    "version": "2022.05.0-2",
+    "version": "2022.05.0-3",
     "slug": "ecowitt",
     "description": "An addon for processing data from Ecowitt Personal Weather Stations",
     "stage": "stable",
@@ -20,7 +20,9 @@
     ],
     "options": {
         "output_unit_system": "imperial",
-        "input_unit_system": "imperial"
+        "input_unit_system": "imperial",
+        "hass_discovery_prefix": "homeassistant",
+        "hass_entity_id_prefix": ""
     },
     "schema": {
         "output_unit_system": "match(imperial|metric)?",
@@ -28,7 +30,9 @@
         "mqtt_host": "str?",
         "mqtt_port": "str?",
         "mqtt_user": "str?",
-        "mqtt_pass": "str?"
+        "mqtt_pass": "str?",
+        "hass_discovery_prefix": "str?",
+        "hass_entity_id_prefix": "str?"
     },
     "ports": {
         "8000/tcp": 8000

--- a/ecowitt/run.sh
+++ b/ecowitt/run.sh
@@ -8,6 +8,7 @@ MQTT_HOST=""
 MQTT_PORT=1883
 MQTT_USER=""
 MQTT_PASS=""
+ADDL_PARAMS=()
 
 if bashio::services.available "mqtt"; then
   MQTT_HOST=$(bashio::services "mqtt" "host")
@@ -43,6 +44,16 @@ else
   INPUT_UNIT_SYSTEM="imperial"
 fi
 
+if bashio::config.has_value 'hass_discovery_prefix'; then
+  HASS_DISCOVERY_PREFIX=$(bashio::config 'hass_discovery_prefix')
+else
+  HASS_DISCOVERY_PREFIX="homeassistant"
+fi
+
+if bashio::config.has_value 'hass_entity_id_prefix'; then
+  ADDL_PARAMS+=(--hass-entity-id-prefix="$(bashio::config 'hass_entity_id_prefix')")
+fi
+
 # Check for MQTT config
 if [[ -z "${MQTT_HOST}" || -z "${MQTT_PORT}" || -z "${MQTT_USER}" || -z "${MQTT_PASS}" ]]; then
   bashio::log.fatal "MQTT Configuration not found, cannot continue."
@@ -59,4 +70,5 @@ ecowitt2mqtt \
     --input-unit-system "${INPUT_UNIT_SYSTEM}" \
     --output-unit-system "${OUTPUT_UNIT_SYSTEM}" \
     --hass-discovery \
-    --port=8000
+    --hass-discovery-prefix="${HASS_DISCOVERY_PREFIX}" \
+    --port=8000 "${ADDL_PARAMS[@]}"

--- a/ecowitt/run.sh
+++ b/ecowitt/run.sh
@@ -52,11 +52,11 @@ fi
 # Boot up
 bashio::log.info "Starting Ecowitt2MQTT"
 ecowitt2mqtt \
-    --mqtt-broker=${MQTT_HOST} \
-    --mqtt-port=${MQTT_PORT} \
-    --mqtt-username=${MQTT_USER} \
-    --mqtt-password=${MQTT_PASS} \
-    --input-unit-system ${INPUT_UNIT_SYSTEM} \
-    --output-unit-system ${OUTPUT_UNIT_SYSTEM} \
+    --mqtt-broker="${MQTT_HOST}" \
+    --mqtt-port="${MQTT_PORT}" \
+    --mqtt-username="${MQTT_USER}" \
+    --mqtt-password="${MQTT_PASS}" \
+    --input-unit-system "${INPUT_UNIT_SYSTEM}" \
+    --output-unit-system "${OUTPUT_UNIT_SYSTEM}" \
     --hass-discovery \
     --port=8000


### PR DESCRIPTION
- Add `hass_discovery_prefix` and `hass_entity_id_prefix` options.
- Wrap all user parameters in quotes to ensure that spaces, accidental or intentional, do not break the startup of the service.

I've tested this out by standing up a mirror under my justfalter account:
https://github.com/justfalter/hassio-addons   ... The prefixes seem to work well in my environment!

<img width="888" alt="image" src="https://user-images.githubusercontent.com/120545/172074221-6906aa6a-f062-4339-b81b-4a2e96b64205.png">
